### PR TITLE
Evolve outline from captured frame

### DIFF
--- a/evolve.frag
+++ b/evolve.frag
@@ -2,8 +2,8 @@ varying vec2 vUv;
 varying vec2 clipMeshCenter;
 varying vec2 glPos;
 
-uniform float time;
 uniform vec2 viewportSize;
+uniform int window;
 
 
 uniform sampler2D gbufferMask;
@@ -16,25 +16,48 @@ void main() {
    float isOutline = texture(gbufferMask, vUv).r;
    float neighbor = 0.;
 
-   vec2 uvCenter   = vUv;
-   vec2 uvTop      = vec2(uvCenter.x,      uvCenter.y - dy);
-   vec2 uvRight    = vec2(uvCenter.x + dx, uvCenter.y);
-   vec2 uvDown      = vec2(uvCenter.x,      uvCenter.y + dy);
-   vec2 uvLeft    = vec2(uvCenter.x - dx, uvCenter.y);
-   vec2 uvTopRight = vec2(uvCenter.x + dx, uvCenter.y - dy);
-   vec2 uvDownLeft = vec2(uvCenter.x - dx, uvCenter.y + dy);
-   vec2 uvTopLeft = vec2(uvCenter.x - dx, uvCenter.y - dy);
-   vec2 uvDownRight = vec2(uvCenter.x + dx, uvCenter.y + dy);
+   vec2 uvCenter = vUv;
 
-   neighbor += texture(initBufferMask, uvCenter).r;
-   neighbor += texture(initBufferMask, uvTop).r;
-   neighbor += texture(initBufferMask, uvRight).r;
-   neighbor += texture(initBufferMask, uvDown).r;
-   neighbor += texture(initBufferMask, uvLeft).r;
-   neighbor += texture(initBufferMask, uvTopRight).r;
-   neighbor += texture(initBufferMask, uvDownLeft).r;
-   neighbor += texture(initBufferMask, uvTopLeft).r;
-   neighbor += texture(initBufferMask, uvDownRight).r;
-   float evolve = clamp(isOutline * neighbor, 0.0, 1.);
-   gl_FragColor = vec4(evolve);
+   if (isOutline > 0.) {
+   float kernelBorder = 0.;
+
+      vec2 uvTop      = vec2(uvCenter.x,      uvCenter.y - dy);
+      vec2 uvRight    = vec2(uvCenter.x + dx, uvCenter.y);
+      vec2 uvDown      = vec2(uvCenter.x,      uvCenter.y + dy);
+      vec2 uvLeft    = vec2(uvCenter.x - dx, uvCenter.y);
+      vec2 uvTopRight = vec2(uvCenter.x + dx, uvCenter.y - dy);
+      vec2 uvDownLeft = vec2(uvCenter.x - dx, uvCenter.y + dy);
+      vec2 uvTopLeft = vec2(uvCenter.x - dx, uvCenter.y - dy);
+      vec2 uvDownRight = vec2(uvCenter.x + dx, uvCenter.y + dy);
+   
+
+      neighbor += texture(initBufferMask, uvCenter).r;
+      neighbor += texture(initBufferMask, uvTop).r;
+      neighbor += texture(initBufferMask, uvRight).r;
+      neighbor += texture(initBufferMask, uvDown).r;
+      neighbor += texture(initBufferMask, uvLeft).r;
+      neighbor += texture(initBufferMask, uvTopRight).r;
+      neighbor += texture(initBufferMask, uvDownLeft).r;
+      neighbor += texture(initBufferMask, uvTopLeft).r;
+      neighbor += texture(initBufferMask, uvDownRight).r;
+
+
+      int windowHalf = window/2;
+      for (int i = -windowHalf; i < windowHalf; i += 1) {
+         for (int j = -windowHalf; j < windowHalf; j += 1) {
+            vec2 texturePoint = vec2(uvCenter.x + float(i) * dx, uvCenter.y + float(j) * dy);
+            kernelBorder += texture(initBufferMask, texturePoint).r;
+         }
+      }
+
+      if (kernelBorder >= 2.0) {
+         neighbor += 1.;
+      }
+      float evolve = clamp(neighbor, 0.0, 1.);
+      gl_FragColor = vec4(evolve);
+   } else {
+      gl_FragColor = vec4(0.);
+      
+   }
+
 }

--- a/evolve.frag
+++ b/evolve.frag
@@ -1,46 +1,8 @@
 varying vec2 vUv;
-varying vec2 clipMeshCenter;
-varying vec2 glPos;
-
-uniform vec2 viewportSize;
-uniform int window;
-
 
 uniform sampler2D gbufferMask;
 uniform sampler2D initBufferMask;
 
 void main() {
-   float dx = 1.0 / viewportSize.x;
-   float dy = 1.0 / viewportSize.y;
-
-   float isOutline = texture(gbufferMask, vUv).r;
-   float neighbor = 0.;
-
-   vec2 uvCenter = vUv;
-
-   if (isOutline > 0.) {
-      vec2 uvTop = vec2(uvCenter.x, uvCenter.y - dy);
-      vec2 uvRight = vec2(uvCenter.x + dx, uvCenter.y);
-      vec2 uvDown = vec2(uvCenter.x, uvCenter.y + dy);
-      vec2 uvLeft = vec2(uvCenter.x - dx, uvCenter.y);
-      vec2 uvTopRight = vec2(uvCenter.x + dx, uvCenter.y - dy);
-      vec2 uvDownLeft = vec2(uvCenter.x - dx, uvCenter.y + dy);
-      vec2 uvTopLeft = vec2(uvCenter.x - dx, uvCenter.y - dy);
-      vec2 uvDownRight = vec2(uvCenter.x + dx, uvCenter.y + dy);
-
-      neighbor += texture(initBufferMask, uvCenter).r;
-      neighbor += texture(initBufferMask, uvTop).r;
-      neighbor += texture(initBufferMask, uvRight).r;
-      neighbor += texture(initBufferMask, uvDown).r;
-      neighbor += texture(initBufferMask, uvLeft).r;
-      neighbor += texture(initBufferMask, uvTopRight).r;
-      neighbor += texture(initBufferMask, uvDownLeft).r;
-      neighbor += texture(initBufferMask, uvTopLeft).r;
-      neighbor += texture(initBufferMask, uvDownRight).r;
-
-      gl_FragColor = vec4(clamp(neighbor, 0.0, 1.));
-   } else {
-      gl_FragColor = vec4(0.);
-   }
-
+   gl_FragColor = vec4(texture(initBufferMask, vUv));
 }

--- a/evolve.frag
+++ b/evolve.frag
@@ -1,0 +1,40 @@
+varying vec2 vUv;
+varying vec2 clipMeshCenter;
+varying vec2 glPos;
+
+uniform float time;
+uniform vec2 viewportSize;
+
+
+uniform sampler2D gbufferMask;
+uniform sampler2D initBufferMask;
+
+void main() {
+   float dx = (1.0 / viewportSize.x);
+   float dy = (1.0 / viewportSize.y);
+
+   float isOutline = texture(gbufferMask, vUv).r;
+   float neighbor = 0.;
+
+   vec2 uvCenter   = vUv;
+   vec2 uvTop      = vec2(uvCenter.x,      uvCenter.y - dy);
+   vec2 uvRight    = vec2(uvCenter.x + dx, uvCenter.y);
+   vec2 uvDown      = vec2(uvCenter.x,      uvCenter.y + dy);
+   vec2 uvLeft    = vec2(uvCenter.x - dx, uvCenter.y);
+   vec2 uvTopRight = vec2(uvCenter.x + dx, uvCenter.y - dy);
+   vec2 uvDownLeft = vec2(uvCenter.x - dx, uvCenter.y + dy);
+   vec2 uvTopLeft = vec2(uvCenter.x - dx, uvCenter.y - dy);
+   vec2 uvDownRight = vec2(uvCenter.x + dx, uvCenter.y + dy);
+
+   neighbor += texture(initBufferMask, uvCenter).r;
+   neighbor += texture(initBufferMask, uvTop).r;
+   neighbor += texture(initBufferMask, uvRight).r;
+   neighbor += texture(initBufferMask, uvDown).r;
+   neighbor += texture(initBufferMask, uvLeft).r;
+   neighbor += texture(initBufferMask, uvTopRight).r;
+   neighbor += texture(initBufferMask, uvDownLeft).r;
+   neighbor += texture(initBufferMask, uvTopLeft).r;
+   neighbor += texture(initBufferMask, uvDownRight).r;
+   float evolve = clamp(isOutline * neighbor, 0.0, 1.);
+   gl_FragColor = vec4(evolve);
+}

--- a/evolve.frag
+++ b/evolve.frag
@@ -42,17 +42,17 @@ void main() {
       neighbor += texture(initBufferMask, uvDownRight).r;
 
 
-      int windowHalf = window/2;
-      for (int i = -windowHalf; i < windowHalf; i += 1) {
-         for (int j = -windowHalf; j < windowHalf; j += 1) {
-            vec2 texturePoint = vec2(uvCenter.x + float(i) * dx, uvCenter.y + float(j) * dy);
-            kernelBorder += texture(initBufferMask, texturePoint).r;
-         }
-      }
+      // int windowHalf = window/2;
+      // for (int i = -windowHalf; i < windowHalf; i += 1) {
+      //    for (int j = -windowHalf; j < windowHalf; j += 1) {
+      //       vec2 texturePoint = vec2(uvCenter.x + float(i) * dx, uvCenter.y + float(j) * dy);
+      //       kernelBorder += texture(initBufferMask, texturePoint).r;
+      //    }
+      // }
 
-      if (kernelBorder >= 2.0) {
-         neighbor += 1.;
-      }
+      // if (kernelBorder >= 2.0) {
+      //    neighbor += 1.;
+      // }
       float evolve = clamp(neighbor, 0.0, 1.);
       gl_FragColor = vec4(evolve);
    } else {

--- a/evolve.frag
+++ b/evolve.frag
@@ -10,8 +10,8 @@ uniform sampler2D gbufferMask;
 uniform sampler2D initBufferMask;
 
 void main() {
-   float dx = (1.0 / viewportSize.x);
-   float dy = (1.0 / viewportSize.y);
+   float dx = 1.0 / viewportSize.x;
+   float dy = 1.0 / viewportSize.y;
 
    float isOutline = texture(gbufferMask, vUv).r;
    float neighbor = 0.;
@@ -19,17 +19,14 @@ void main() {
    vec2 uvCenter = vUv;
 
    if (isOutline > 0.) {
-   float kernelBorder = 0.;
-
-      vec2 uvTop      = vec2(uvCenter.x,      uvCenter.y - dy);
-      vec2 uvRight    = vec2(uvCenter.x + dx, uvCenter.y);
-      vec2 uvDown      = vec2(uvCenter.x,      uvCenter.y + dy);
-      vec2 uvLeft    = vec2(uvCenter.x - dx, uvCenter.y);
+      vec2 uvTop = vec2(uvCenter.x, uvCenter.y - dy);
+      vec2 uvRight = vec2(uvCenter.x + dx, uvCenter.y);
+      vec2 uvDown = vec2(uvCenter.x, uvCenter.y + dy);
+      vec2 uvLeft = vec2(uvCenter.x - dx, uvCenter.y);
       vec2 uvTopRight = vec2(uvCenter.x + dx, uvCenter.y - dy);
       vec2 uvDownLeft = vec2(uvCenter.x - dx, uvCenter.y + dy);
       vec2 uvTopLeft = vec2(uvCenter.x - dx, uvCenter.y - dy);
       vec2 uvDownRight = vec2(uvCenter.x + dx, uvCenter.y + dy);
-   
 
       neighbor += texture(initBufferMask, uvCenter).r;
       neighbor += texture(initBufferMask, uvTop).r;
@@ -41,23 +38,9 @@ void main() {
       neighbor += texture(initBufferMask, uvTopLeft).r;
       neighbor += texture(initBufferMask, uvDownRight).r;
 
-
-      // int windowHalf = window/2;
-      // for (int i = -windowHalf; i < windowHalf; i += 1) {
-      //    for (int j = -windowHalf; j < windowHalf; j += 1) {
-      //       vec2 texturePoint = vec2(uvCenter.x + float(i) * dx, uvCenter.y + float(j) * dy);
-      //       kernelBorder += texture(initBufferMask, texturePoint).r;
-      //    }
-      // }
-
-      // if (kernelBorder >= 2.0) {
-      //    neighbor += 1.;
-      // }
-      float evolve = clamp(neighbor, 0.0, 1.);
-      gl_FragColor = vec4(evolve);
+      gl_FragColor = vec4(clamp(neighbor, 0.0, 1.));
    } else {
       gl_FragColor = vec4(0.);
-      
    }
 
 }

--- a/evolve.vert
+++ b/evolve.vert
@@ -1,7 +1,7 @@
 varying vec2 vUv;
 uniform vec3 meshCenter;
 varying vec2 clipMeshCenter;
-uniform float time;
+uniform int window;
 varying vec2 glPos;
 
 void main() {

--- a/evolve.vert
+++ b/evolve.vert
@@ -1,0 +1,14 @@
+varying vec2 vUv;
+uniform vec3 meshCenter;
+varying vec2 clipMeshCenter;
+uniform float time;
+varying vec2 glPos;
+
+void main() {
+    clipMeshCenter = (projectionMatrix * modelViewMatrix * vec4(meshCenter, 1.0)).xy;
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    vUv = gl_Position.xy / gl_Position.w;
+    vUv = (vUv + 1.0) * 0.5;
+    glPos = gl_Position.xy;
+}

--- a/evolve.vert
+++ b/evolve.vert
@@ -1,14 +1,8 @@
 varying vec2 vUv;
-uniform vec3 meshCenter;
-varying vec2 clipMeshCenter;
-uniform int window;
-varying vec2 glPos;
 
 void main() {
-    clipMeshCenter = (projectionMatrix * modelViewMatrix * vec4(meshCenter, 1.0)).xy;
     vUv = uv;
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
     vUv = gl_Position.xy / gl_Position.w;
     vUv = (vUv + 1.0) * 0.5;
-    glPos = gl_Position.xy;
 }

--- a/main.js
+++ b/main.js
@@ -117,8 +117,6 @@ function continuity(bitmap, width, height) {
         const pointIsRoot = row == rootRow && col == rootCol;
         const pointIsSentinel = isSentinel(row, col);
 
-        // Just make sure we aren't choosing a point that's too close to the root
-        // itself. Walk about 20 steps. This number was chosen arbitrarily.
         if (steps != 0 && pointIsRoot) {
             cyclic.push([row, col]);
             return;

--- a/main.js
+++ b/main.js
@@ -119,7 +119,7 @@ function continuity(bitmap, width, height) {
 
         // Just make sure we aren't choosing a point that's too close to the root
         // itself. Walk about 20 steps. This number was chosen arbitrarily.
-        if (steps > 20 && pointIsRoot) {
+        if (steps != 0 && pointIsRoot) {
             cyclic.push([row, col]);
             return;
         }
@@ -140,7 +140,7 @@ function continuity(bitmap, width, height) {
         dfs(row, col - 1, rootRow, rootCol, steps + 1)
         dfs(row, col + 1, rootRow, rootCol, steps + 1)
 
-        if (!pointIsRoot && pointIsSentinel && steps > 20) {
+        if (!pointIsRoot && pointIsSentinel && steps != 0) {
             sentinels.push([row, col]);
         }
         return;

--- a/main.js
+++ b/main.js
@@ -211,7 +211,7 @@ const clock = new THREE.Clock();
 var longestPixelStrand = 0;
 var init = true;
 const allThePixels = new Uint8Array(buffer.width * buffer.height * 4);
-const dijkstraBuffer = new Float32Array(buffer.width * buffer.height * 4);
+const dijkstraBuffer = new Uint32Array(buffer.width * buffer.height * 4);
 function animate() {
 
     if (init) {

--- a/main.js
+++ b/main.js
@@ -24,7 +24,8 @@ light.position.set(10, 10, 15);
 solidScene.add(light);
 camera.position.set(6,8,14);
 
-var buffer = new THREE.WebGLRenderTarget(width, height, {format: THREE.RGBFormat})
+var buffer = new THREE.WebGLRenderTarget(width, height, {format: THREE.RGBAFormat, type: THREE.FloatType})
+var outlineBuffer = new THREE.WebGLRenderTarget(width, height, {format: THREE.RGBAFormat, type: THREE.FloatType})
 
 const orbit = new OrbitControls(camera, renderer.domElement);
 orbit.update();
@@ -69,14 +70,105 @@ solidScene.add(solidMesh);
 scene.add(mesh);
 maskScene.add(shadowMesh);
 
+function continuity(bitmap, width, height) {
+    const visited = Array.from({length: height}, () => Array(width).fill(false));
+
+    function valid(row, col) {
+        return row >= 0 && row < height && col >= 0 && col <= width
+    }
+
+    var sentinels = [];
+    var cyclic = [];
+
+    function dfs(row, col, rootRow, rootCol, steps) {
+
+        if (steps > 20 && row == rootRow && col == rootCol) {
+            
+            cyclic.push([row, col]);
+        }
+
+        if (!valid(row, col) || visited[row][col]) {
+            return 1; // is this a sentinel point
+        }
+        var point = 4 * (row * width + col);
+        if (bitmap[point+0] == 0 && bitmap[point+1] == 0 && bitmap[point+2] == 0) {
+            return 0;
+        }
+
+        visited[row][col] = true;
+        dfs(row - 1, col, rootRow, rootCol, steps + 1)
+        dfs(row + 1, col, rootRow, rootCol, steps + 1)
+        dfs(row, col - 1, rootRow, rootCol, steps + 1)
+        dfs(row, col + 1, rootRow, rootCol, steps + 1)
+
+        var amISentinel = (
+            Number(valid(row - 1, col - 1)) +
+            Number(valid(row - 1, col)) +
+            Number(valid(row - 1, col + 1)) +
+
+            Number(valid(row, col - 1)) +
+            Number(valid(row, col + 1)) +
+
+            Number(valid(row + 1, col - 1)) +
+            Number(valid(row + 1, col)) +
+            Number(valid(row + 1, col + 1))
+        )
+
+        // if (Math.abs(row - rootRow) < 2 && Math.abs(col - rootCol) < 2) {
+        //     return 1;
+        // }
+
+        // for a point to be on the screen edge, it must have at least three
+        // of its neighbors invalid
+        if (amISentinel < 6) {
+            sentinels.push([row, col]);
+        }
+        return 0;
+    }
+
+    for (let row = 0; row < height; row++) {
+        for(let col=0; col<width; col++) {
+            var point = 4 * (row * width + col);
+            if (!visited[row][col] && bitmap[point+0] == 1 && bitmap[point+1] == 1 && bitmap[point+2] == 1) {
+                dfs(row, col, row, col, 0);
+            }
+        }
+    }
+
+    console.log(cyclic)
+}
+
 const clock = new THREE.Clock();
 function animate() {
 
     uniforms.time.value = clock.getElapsedTime();
 
-    renderer.clear()
     renderer.setRenderTarget(buffer);
     renderer.render(maskScene, camera);
+
+    renderer.setRenderTarget(outlineBuffer);
+    renderer.render(scene, camera);
+
+    const allThePixels = new Float32Array( buffer.width * buffer.height * 4);
+
+    var litPixels = 0;
+    renderer.readRenderTargetPixels( outlineBuffer, 0, 0, buffer.width, buffer.height, allThePixels);
+
+    // var pixel;
+  //    for (let y = 0; y < buffer.height; y++) {
+  //       for (let x = 0; x < buffer.width; x++) {
+  //          var at = 4 * (y * buffer.width + x);
+  //          // console.log(`${x}, ${y}`);
+  //    	    const isLit = allThePixels[at] == 1 && allThePixels[at+1] == 1 && allThePixels[at+2] == 1 && allThePixels[at+3] == 1
+  //       		if (isLit) {
+  //       		    litPixels += 1;
+  //       		}
+  //       }
+  //    }
+    
+		// console.log(litPixels);
+		continuity(allThePixels, width, height)
+
 
     renderer.setRenderTarget(null);
     renderer.render(solidScene, camera);

--- a/main.js
+++ b/main.js
@@ -164,7 +164,7 @@ var durationInSeconds = 5;
 // @param {Float32Array} allThePixels
 // Number all the points as we stumble along the outline.
 // Akin to a wavefront. The pixels switched on (value = 1)
-// touching the wavefron at time t will have a value t + 2
+// touching the wavefront at time t will have a value t + 2
 //
 // This way we can quickly zero out all the pixels below a
 // threshold when timing the animation.

--- a/main.js
+++ b/main.js
@@ -145,8 +145,11 @@ function continuity(bitmap, width, height) {
 
     for (let row = 0; row < height; row++) {
         for(let col=0; col < width; col++) {
+            if (visited[row][col]) {
+                continue;
+            }
             var point = 4 * (row * width + col);
-            if (!visited[row][col] && bitmap[point+0] == 1 && bitmap[point+1] == 1 && bitmap[point+2] == 1) {
+            if (bitmap[point] == 1 && bitmap[point+1] == 1 && bitmap[point+2] == 1) {
                 dfs(row, col, row, col, 0);
             }
         }

--- a/main.js
+++ b/main.js
@@ -67,7 +67,7 @@ maskScene.add(shadowMesh);
 
 
 const evoUniforms = {
-    initBufferMask: { value: new Float32Array(width * height * 4) },
+    initBufferMask: { value: null },
 }
 
 const evoMaterial = new THREE.ShaderMaterial({

--- a/main.js
+++ b/main.js
@@ -115,7 +115,6 @@ function continuity(bitmap, width, height) {
     function dfs(row, col, rootRow, rootCol, steps) {
 
         const pointIsRoot = row == rootRow && col == rootCol;
-        const pointIsSentinel = isSentinel(row, col);
 
         if (steps != 0 && pointIsRoot) {
             cyclic.push([row, col]);
@@ -138,7 +137,7 @@ function continuity(bitmap, width, height) {
         dfs(row, col - 1, rootRow, rootCol, steps + 1)
         dfs(row, col + 1, rootRow, rootCol, steps + 1)
 
-        if (!pointIsRoot && pointIsSentinel && steps != 0) {
+        if (isSentinel(row, col) && steps != 0) {
             sentinels.push([row, col]);
         }
         return;

--- a/main.js
+++ b/main.js
@@ -201,10 +201,10 @@ var init = true;
 const allThePixels = new Float32Array( buffer.width * buffer.height * 4);
 function animate() {
 
-    renderer.setRenderTarget(buffer);
-    renderer.render(maskScene, camera);
-
     if (init) {
+        renderer.setRenderTarget(buffer);
+        renderer.render(maskScene, camera);
+
         renderer.setRenderTarget(outlineBuffer);
         renderer.render(scene, camera);
 

--- a/main.js
+++ b/main.js
@@ -172,8 +172,6 @@ function continuity(bitmap, width, height) {
     return [cyclic.concat(sentinels), duration];
 }
 
-var init = true;
-
 var durationInSeconds = 5;
 
 // @param {Float32Array[]} points
@@ -209,6 +207,7 @@ function dijkstraPropagate(point, allThePixels, value) {
 
 const clock = new THREE.Clock();
 var longestPixelStrand = 0;
+var init = true;
 const allThePixels = new Float32Array( buffer.width * buffer.height * 4);
 function animate() {
 
@@ -217,10 +216,10 @@ function animate() {
     renderer.setRenderTarget(buffer);
     renderer.render(maskScene, camera);
 
-    renderer.setRenderTarget(outlineBuffer);
-    renderer.render(scene, camera);
-
     if (init) {
+        renderer.setRenderTarget(outlineBuffer);
+        renderer.render(scene, camera);
+
         renderer.readRenderTargetPixels(outlineBuffer, 0, 0, buffer.width, buffer.height, allThePixels);
 
     		let [points, duration] = continuity(allThePixels, width, height)
@@ -255,7 +254,6 @@ function animate() {
         for(let col=0; col<width; col++) {
             var point = 4 * (row * width + col);
             if (allThePixels[point] > 1 && allThePixels[point] < pixelsAnimated) {
-                // console.log(rawPoint)
                 initBuffer[point] = 255;
                 initBuffer[point+1] = 255;
                 initBuffer[point+2] = 255;
@@ -266,7 +264,6 @@ function animate() {
     let ephemeralTex = new THREE.DataTexture(initBuffer, width, height);
     ephemeralTex.needsUpdate = true;
     evoUniforms.initBufferMask.value = ephemeralTex;
-		// console.log(pixelsAnimated)
 
     renderer.setRenderTarget(null);
     renderer.render(solidScene, camera);
@@ -284,4 +281,9 @@ window.addEventListener('resize', function() {
     camera.aspect = width / height;
     camera.updateProjectionMatrix();
     renderer.setSize(width, height);
+    init = true;
 });
+
+orbit.addEventListener('change', function() {
+    init = true;
+})

--- a/outline.frag
+++ b/outline.frag
@@ -44,21 +44,9 @@ void main() {
    delta = max(delta, dL);
    delta = max(delta, dDL);
 
-
-
    float threshold = 0.0;
-   float deltaClipped = clamp((delta * 2.0) - threshold, 0.0, 1.0);
+   float isOutline = clamp((delta * 2.0) - threshold, 0.0, 1.0);
 
-   vec2 fromOrigin = glPos - clipMeshCenter;
-   // angle, normalized to the range [0, 1]
-   float angle = atan(fromOrigin.y, fromOrigin.x) / (2.0 * 3.141592653589793);
-   if (angle < 0. && fromOrigin.y < 0.) {
-      angle += 1.;
-   }
-   // float pct = fract(time * .5);
-   // float angleThres = angle < pct ? 1.0: 0.0;
-   float isOutline = deltaClipped;
-
-   vec4 outline = vec4(vec3(isOutline), isOutline);
+   vec4 outline = vec4(isOutline);
    gl_FragColor = outline;
 }

--- a/outline.frag
+++ b/outline.frag
@@ -7,7 +7,7 @@ uniform vec2 viewportSize;
 
 #define LINE_WEIGHT 2.0
 
-uniform sampler2D gbufferMask; //the object red and bg black or transparent
+uniform sampler2D gbufferMask;
 
 void main() {
    float dx = (1.0 / viewportSize.x) * LINE_WEIGHT;
@@ -55,9 +55,9 @@ void main() {
    if (angle < 0. && fromOrigin.y < 0.) {
       angle += 1.;
    }
-   float pct = fract(time * .5);
-   float angleThres = angle < pct ? 1.0: 0.0;
-   float isOutline = deltaClipped * angleThres;
+   // float pct = fract(time * .5);
+   // float angleThres = angle < pct ? 1.0: 0.0;
+   float isOutline = deltaClipped;
 
    vec4 outline = vec4(vec3(isOutline), isOutline);
    gl_FragColor = outline;


### PR DESCRIPTION
### Changes
- Added shaders under the `evolve` prefix. These are copy shaders so that we can apply them on an object instead of a fullscreen quad.
- We no longer need to calculate the mesh center.

### How the evolution works
- Use the outline shader to capture an entire render frame to a render target `outlineBuffer`.
- Read said buffer's texture pixels into a `Float32Array`.
- Start walking from an arbitrary point.
  - If a point is on the screen edge, mark it as `sentinel`.
  - If a point is visited twice, it is on a loop. Mark it as `cyclic`.
- Start a wavefront (increasing contour lines) from cyclic and sentinel points. Number the pixels accordingly.
- Find the longest strand of pixels. The total animation duration `S` must correspond to this length `l`.
- Translate time elapsed `t` to pixels by `p = t * l/S`. This is our threshold.
- Zero out all the pixels tagged with values less than this threshold.
- Paint the buffer.